### PR TITLE
Policyをdigestに変換できるようにした

### DIFF
--- a/lib/clay_policy.js
+++ b/lib/clay_policy.js
@@ -9,6 +9,7 @@ const { PolicyError } = require('clay-errors')
 const { restrictionHelper, validationHelper } = require('./helpers')
 const { cleanup } = require('asobj')
 const Reasons = require('./reasons')
+const { digestJson } = require('adigest')
 const { requiredFields, validateRestrictions } = restrictionHelper
 const {
   isMissing,
@@ -128,6 +129,25 @@ class ClayPolicy {
     const s = this
     const { $$fields } = s
     return new ClayPolicy($$fields)
+  }
+
+  /**
+   * Convert into JSON compatible values
+   * @returns {Object} Values
+   */
+  toValues () {
+    const s = this
+    const { $$fields } = s
+    return Object.assign({}, $$fields)
+  }
+
+  /**
+   * To digest string
+   * @returns {string} Digest String
+   */
+  toDigest () {
+    const s = this
+    return digestJson(s.toValues())
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/realglobe-Inc/clay-policy#readme",
   "dependencies": {
+    "adigest": "^1.0.2",
     "asobj": "^1.5.0",
     "clay-constants": "^2.6.1",
     "clay-entity": "^1.5.2",

--- a/test/clay_policy_test.js
+++ b/test/clay_policy_test.js
@@ -6,7 +6,7 @@
 
 const ClayPolicy = require('../lib/clay_policy.js')
 const Types = require('../lib/types')
-const { deepEqual, ok } = require('assert')
+const { deepEqual, equal, notEqual, ok } = require('assert')
 const co = require('co')
 
 describe('clay-policy', function () {
@@ -91,6 +91,17 @@ describe('clay-policy', function () {
     let policy02 = new ClayPolicy(policy)
     ok(policy02.validate({ foo: null }))
     ok(!policy02.validate({ foo: 'bar' }))
+  }))
+
+  it('Digest', () => co(function * () {
+    equal(
+      new ClayPolicy({ foo: { type: Types.STRING } }).toDigest(),
+      new ClayPolicy({ foo: { type: Types.STRING } }).toDigest()
+    )
+    notEqual(
+      new ClayPolicy({ foo: { type: Types.STRING } }).toDigest(),
+      new ClayPolicy({ bar: { type: Types.STRING } }).toDigest()
+    )
   }))
 })
 


### PR DESCRIPTION
policyそのものもresourceとして永続化されるので、プログラム側と差異が出てくる恐れがある。
変更を検知するために、policyの中身をdigestして一緒に保管できるようにする必要がある

```javascript
const policy = clayPolicy({
  username: { type: 'STRING' }
})
let policyDigest = policy.toDigest() // Convert into digest string
```