### PR TITLE
Add unique filter methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Field Restrictions
 API Guide
 -----
 
-+ [clay-policy@1.3.1](./doc/api/api.md)
++ [clay-policy@1.3.2](./doc/api/api.md)
   + [create(args)](./doc/api/api.md#clay-policy-function-create)
   + [isPolicy(obj)](./doc/api/api.md#clay-policy-function-is-policy)
   + [ClayPolicy](./doc/api/api.md#clay-policy-class)

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-policy@1.3.1
+# clay-policy@1.3.2
 
 Schema helpers for ClayDB resources
 

--- a/lib/clay_policy.js
+++ b/lib/clay_policy.js
@@ -10,7 +10,12 @@ const { restrictionHelper, validationHelper } = require('./helpers')
 const { cleanup } = require('asobj')
 const Reasons = require('./reasons')
 const { digestJson } = require('adigest')
-const { requiredFieldNames, formatRestrictions, validateRestrictions } = restrictionHelper
+const {
+  requiredFieldNames,
+  uniqueFieldNames,
+  formatRestrictions,
+  validateRestrictions
+} = restrictionHelper
 const {
   isMissing,
   isTypeOf,
@@ -81,6 +86,19 @@ class ClayPolicy {
     if (error) {
       throw error
     }
+  }
+
+  /**
+   * Define unique filter objects for entity
+   * @param {ClayEntity} entity - Entity to work with
+   * @returns {Object[]} Value filter objects
+   */
+  uniqueFilters (entity) {
+    const s = this
+    const { $$restrictions } = s
+    return uniqueFieldNames($$restrictions).map((name) => ({
+      [name]: entity[ name ]
+    }))
   }
 
   /**

--- a/lib/helpers/restriction_helper.js
+++ b/lib/helpers/restriction_helper.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const fieldNames = ($$policy) => Object.keys($$policy || {}).filter((name) => !/^\$/.test(name))
+
 const { PolicySchema } = require('clay-schemas')
 const { LogPrefixes } = require('clay-constants')
 const { POLICY_PREFIX } = LogPrefixes
@@ -22,6 +23,15 @@ module.exports = Object.assign(exports, {
    */
   requiredFieldNames ($$restrictions) {
     return fieldNames($$restrictions).filter((name) => $$restrictions[ name ].required)
+  },
+
+  /**
+   * Get unique field names
+   * @param {Object} $$restrictions
+   * @returns {string[]}
+   */
+  uniqueFieldNames ($$restrictions) {
+    return fieldNames($$restrictions).filter((name) => $$restrictions[ name ].unique)
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-policy",
-  "version": "1.3.2",
+  "version": "1.5.0",
   "description": "Schema helpers for ClayDB resources",
   "browser": "shim/browser",
   "main": "lib",

--- a/test/clay_policy_test.js
+++ b/test/clay_policy_test.js
@@ -133,6 +133,14 @@ describe('clay-policy', function () {
     })
     ok(!policy.validate({ 'bar': 1 }))
   }))
+
+  it('Unique filters', () => co(function * () {
+    let policy = new ClayPolicy({
+      foo: { type: 'STRING', unique: true }
+    })
+    let filters = policy.uniqueFilters({ foo: 'bar', 'baz': 'quz' })
+    deepEqual(filters, [ { foo: 'bar' } ])
+  }))
 })
 
 /* global describe, before, after, it */


### PR DESCRIPTION
Unique制約の実現のために、policyからuniqueな条件を生成するためのメソッドを追加

```javascript
it('Unique filters', () => co(function * () {
    let policy = new ClayPolicy({
      foo: { type: 'STRING', unique: true }
    })
    let filters = policy.uniqueFilters({ foo: 'bar', 'baz': 'quz' })
    deepEqual(filters, [ { foo: 'bar' } ])
  }))
```