### PR TITLE
Defaultsとして埋めるべき値を取れるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Field Restrictions
 | **type** | string | Type of the field |  |
 | **oneOf** | array | Enum values for the field |  |
 | **required** | boolean | Value is required for the field |  |
-| **default** | any | Default value of the field |  |
+| **default** |  | Default value of the field |  |
 | **unique** | boolean | Add unique constraint on the field |  |
 | **minimum** | number | Minimum value of the field |  |
 | **maximum** | number | Maximum value of the field |  |
@@ -153,7 +153,7 @@ Field Restrictions
 API Guide
 -----
 
-+ [clay-policy@2.0.0](./doc/api/api.md)
++ [clay-policy@2.0.1](./doc/api/api.md)
   + [create(args)](./doc/api/api.md#clay-policy-function-create)
   + [isPolicy(obj)](./doc/api/api.md#clay-policy-function-is-policy)
   + [ClayPolicy](./doc/api/api.md#clay-policy-class)

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -10,7 +10,7 @@ Schema helpers for ClayDB resources
   + [policy.validate(entity)](#clay-policy-class-clay-policy-validate)
   + [policy.validateToThrow(entity)](#clay-policy-class-clay-policy-validateToThrow)
   + [policy.uniqueFilters(entity)](#clay-policy-class-clay-policy-uniqueFilters)
-  + [policy.assigning(entity)](#clay-policy-class-clay-policy-assigning)
+  + [policy.defaultsFor(entity)](#clay-policy-class-clay-policy-defaultsFor)
   + [policy.testRestriction(restriction, value)](#clay-policy-class-clay-policy-testRestriction)
   + [policy.hasRestrictionFor(name)](#clay-policy-class-clay-policy-hasRestrictionFor)
   + [policy.clone()](#clay-policy-class-clay-policy-clone)
@@ -94,11 +94,11 @@ Define unique filter objects for entity
 | entity | ClayEntity | Entity to work with |
 
 
-<a class='md-heading-link' name="clay-policy-class-clay-policy-assigning" ></a>
+<a class='md-heading-link' name="clay-policy-class-clay-policy-defaultsFor" ></a>
 
-### policy.assigning(entity) -> `Object`
+### policy.defaultsFor(entity) -> `Object`
 
-Get assigning values (defaults to fill)
+Get defaults values for an entity. This method does NOT update the passed entity
 
 | Param | Type | Description |
 | ----- | --- | -------- |

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-policy@2.0.0
+# clay-policy@2.0.1
 
 Schema helpers for ClayDB resources
 
@@ -10,6 +10,7 @@ Schema helpers for ClayDB resources
   + [policy.validate(entity)](#clay-policy-class-clay-policy-validate)
   + [policy.validateToThrow(entity)](#clay-policy-class-clay-policy-validateToThrow)
   + [policy.uniqueFilters(entity)](#clay-policy-class-clay-policy-uniqueFilters)
+  + [policy.assigning(entity)](#clay-policy-class-clay-policy-assigning)
   + [policy.testRestriction(restriction, value)](#clay-policy-class-clay-policy-testRestriction)
   + [policy.hasRestrictionFor(name)](#clay-policy-class-clay-policy-hasRestrictionFor)
   + [policy.clone()](#clay-policy-class-clay-policy-clone)
@@ -91,6 +92,17 @@ Define unique filter objects for entity
 | Param | Type | Description |
 | ----- | --- | -------- |
 | entity | ClayEntity | Entity to work with |
+
+
+<a class='md-heading-link' name="clay-policy-class-clay-policy-assigning" ></a>
+
+### policy.assigning(entity) -> `Object`
+
+Get assigning values (defaults to fill)
+
+| Param | Type | Description |
+| ----- | --- | -------- |
+| entity | ClayEntity |  |
 
 
 <a class='md-heading-link' name="clay-policy-class-clay-policy-testRestriction" ></a>

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -83,6 +83,27 @@
           }
         },
         {
+          "name": "assigning",
+          "access": "",
+          "virtual": false,
+          "description": "Get assigning values (defaults to fill)",
+          "parameters": [
+            {
+              "name": "entity",
+              "type": "ClayEntity",
+              "description": "",
+              "default": "",
+              "optional": "",
+              "nullable": ""
+            }
+          ],
+          "examples": [],
+          "returns": {
+            "type": "Object",
+            "description": "Properties to assign"
+          }
+        },
+        {
           "name": "testRestriction",
           "access": "",
           "virtual": false,

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -83,10 +83,10 @@
           }
         },
         {
-          "name": "assigning",
+          "name": "defaultsFor",
           "access": "",
           "virtual": false,
-          "description": "Get assigning values (defaults to fill)",
+          "description": "Get defaults values for an entity. This method does NOT update the passed entity",
           "parameters": [
             {
               "name": "entity",
@@ -100,7 +100,7 @@
           "examples": [],
           "returns": {
             "type": "Object",
-            "description": "Properties to assign"
+            "description": "Default values"
           }
         },
         {

--- a/lib/clay_policy.js
+++ b/lib/clay_policy.js
@@ -103,11 +103,11 @@ class ClayPolicy {
   }
 
   /**
-   * Get assigning values (defaults to fill)
+   * Get defaults values for an entity. This method does NOT update the passed entity
    * @param {ClayEntity} entity
-   * @returns {Object} Properties to assign
+   * @returns {Object} Default values
    */
-  assigning (entity) {
+  defaultsFor (entity) {
     const s = this
     const { $$restrictions } = s
     let assignable = defaultValues($$restrictions)

--- a/lib/clay_policy.js
+++ b/lib/clay_policy.js
@@ -13,6 +13,7 @@ const { digestJson } = require('adigest')
 const {
   requiredFieldNames,
   uniqueFieldNames,
+  defaultValues,
   formatRestrictions,
   validateRestrictions
 } = restrictionHelper
@@ -99,6 +100,23 @@ class ClayPolicy {
     return uniqueFieldNames($$restrictions).map((name) => ({
       [name]: entity[ name ]
     }))
+  }
+
+  /**
+   * Get assigning values (defaults to fill)
+   * @param {ClayEntity} entity
+   * @returns {Object} Properties to assign
+   */
+  assigning (entity) {
+    const s = this
+    const { $$restrictions } = s
+    let assignable = defaultValues($$restrictions)
+    let asValue = (value) => typeof value === 'function' ? value() : value
+    return Object.keys(assignable)
+      .filter((name) => typeof entity[ name ] === 'undefined')
+      .reduce((assigning, name) => Object.assign(assigning, {
+        [name]: asValue(assignable[ name ])
+      }), {})
   }
 
   /**

--- a/lib/helpers/restriction_helper.js
+++ b/lib/helpers/restriction_helper.js
@@ -80,6 +80,19 @@ module.exports = Object.assign(exports, {
         console.warn(`${POLICY_PREFIX} Unknown type "${type}" passed for field "${name}"`)
       }
     }
+  },
+
+  /**
+   * Get default values
+   * @param $$restrictions
+   * @returns {Object}
+   */
+  defaultValues ($$restrictions) {
+    return fieldNames($$restrictions)
+      .filter((name) => $$restrictions[ name ].hasOwnProperty('default'))
+      .reduce((defaults, name) => Object.assign(defaults, {
+        [name]: $$restrictions[ name ][ 'default' ]
+      }), {})
   }
 
 })

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "clay-constants": "^3.0.1",
     "clay-entity": "^2.0.1",
     "clay-errors": "^3.0.1",
-    "clay-schemas": "^4.0.2",
-    "clay-serial": "^2.0.1",
+    "clay-schemas": "^4.0.3",
+    "clay-serial": "^2.0.2",
     "co": "^4.6.0",
     "tv4": "^1.3.0"
   },

--- a/test/clay_policy_test.js
+++ b/test/clay_policy_test.js
@@ -141,6 +141,24 @@ describe('clay-policy', function () {
     let filters = policy.uniqueFilters({ foo: 'bar', 'baz': 'quz' })
     deepEqual(filters, [ { foo: 'bar' } ])
   }))
+
+  it('Default values', () => co(function * () {
+    let policy = new ClayPolicy({
+      hoge: {
+        type: 'STRING',
+        default: () => 'a'
+      },
+      bar: {
+        type: 'STRING',
+        default: 'b'
+      }
+    })
+    let entity = { 'bar': 'jj' }
+    ok(!policy.validate(entity))
+
+    let assigning = policy.assigning(entity)
+    deepEqual(assigning, { hoge: 'a' }, 'Fill defaults')
+  }))
 })
 
 /* global describe, before, after, it */

--- a/test/clay_policy_test.js
+++ b/test/clay_policy_test.js
@@ -156,8 +156,8 @@ describe('clay-policy', function () {
     let entity = { 'bar': 'jj' }
     ok(!policy.validate(entity))
 
-    let assigning = policy.assigning(entity)
-    deepEqual(assigning, { hoge: 'a' }, 'Fill defaults')
+    let defaultsFor = policy.defaultsFor(entity)
+    deepEqual(defaultsFor, { hoge: 'a' }, 'Fill defaults')
   }))
 })
 


### PR DESCRIPTION
ここでは埋め込み自体はしない。関数だったら実行する。

```javascript
it('Default values', () => co(function * () {
    let policy = new ClayPolicy({
      hoge: {
        type: 'STRING',
        default: () => 'a'
      },
      bar: {
        type: 'STRING',
        default: 'b'
      }
    })
    let entity = { 'bar': 'jj' }
    ok(!policy.validate(entity))

    let defaultsFor = policy.defaultsFor(entity)
    deepEqual(defaultsFor, { hoge: 'a' }, 'Fill defaults')
  }))
```