### PR TITLE
Fix value length validation

### DIFF
--- a/lib/clay_policy.js
+++ b/lib/clay_policy.js
@@ -230,7 +230,7 @@ class ClayPolicy {
         }, additionalInfo)
       }
     }
-    if (value && value.hasOwnProperty('length')) {
+    if (value !== null && value !== undefined && value.hasOwnProperty('length')) {
       let lengthFail = !inRange([minLength, maxLength], value.length)
       if (lengthFail) {
         return failure(LENGTH_OUT_OF_RANGE, {


### PR DESCRIPTION
value が `''` や `0` のときにlengthに関するvalidationをすりぬけてしまうので修正しました。