### PR TITLE
Avoid Number(object) in testRestriction()

### DIFF
--- a/lib/clay_policy.js
+++ b/lib/clay_policy.js
@@ -214,7 +214,7 @@ class ClayPolicy {
     if (patternFail) {
       return failure(PATTERN_NOT_MATCHED, {actual: value, expects: pattern}, additionalInfo)
     }
-    const valueAsNumber = Number(value)
+    const valueAsNumber = typeof value === 'object' ? NaN : Number(value)
     if (!isNaN(valueAsNumber)) {
       const rangeFail = !inRange([minimum, maximum], valueAsNumber, {exclusive: [exclusiveMinimum, exclusiveMaximum]})
       if (rangeFail) {


### PR DESCRIPTION
`Number()` はどんな引数でも受け止めてくれて数値に変換できなかったら NaN を返す優しい関数だと思っていました。

```
> Number({})
NaN
```

ところが、特定のオブジェクを渡すとエラーになってしまいます。

```
> Number({toString: null})
TypeError: Cannot convert object to primitive value
    at Number (<anonymous>)
```
なので、 Number にうかつにオブジェクトを渡すのをやめました。
